### PR TITLE
Some assignments are broken and cause compilation error

### DIFF
--- a/resource_server.go
+++ b/resource_server.go
@@ -45,7 +45,7 @@ func resourceServer() *schema.Resource {
 				Required: true,
 			},
 			"environment_id": &schema.Schema{
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Optional: true,
 			},
 			"location_id": &schema.Schema{
@@ -80,7 +80,7 @@ func resourceServer() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"puppetclass_ids": &schema.Schema{
+			"puppet_class_ids": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
@@ -89,7 +89,7 @@ func resourceServer() *schema.Resource {
 				},
 			},
 			"operatingsystem_id": &schema.Schema{
-				Type:     schema.TypeString, //Why isnt this an Int? API doco may be incorrect
+				Type:     schema.TypeInt, //Why isnt this an Int? API doco may be incorrect
 				Optional: true,
 			},
 			"medium_id": &schema.Schema{
@@ -533,7 +533,7 @@ func buildHostStruct(d *schema.ResourceData, meta interface{}) foreman.Host {
 
 	// populate h struct instance for regular level data
 	if v, ok := d.GetOk("environment_id"); ok {
-		h.Environment_id = v.(string)
+		h.Environment_id = v.(int)
 	}
 	if v, ok := d.GetOk("organization_id"); ok {
 		h.Organization_id = v.(int)
@@ -563,10 +563,10 @@ func buildHostStruct(d *schema.ResourceData, meta interface{}) foreman.Host {
 		h.Puppetclass_ids = v.([]int)
 	}
 	if v, ok := d.GetOk("operatingsystem_id"); ok {
-		h.Operatingsystem_id = v.(string)
+		h.Operatingsystem_id = v.(int)
 	}
 	if v, ok := d.GetOk("medium_id"); ok {
-		h.Medium_id = v.(string)
+		h.Medium_id = v.(int)
 	}
 	if v, ok := d.GetOk("ptable_id"); ok {
 		h.Ptable_id = v.(int)
@@ -619,7 +619,7 @@ func buildHostStruct(d *schema.ResourceData, meta interface{}) foreman.Host {
 		h.Comment = v.(string)
 	}
 	if v, ok := d.GetOk("capabilities"); ok {
-		h.Capabilities = v.(string)
+		h.Capabilities = v.([]interface{})
 	}
 	if v, ok := d.GetOk("compute_profile_id"); ok {
 		h.Compute_profile_id = v.(int)


### PR DESCRIPTION
Hi Mattwilmott,

Thank's for your great job ! Build seems ko, I suggest you few modifications. 

### Go Version
go version go1.8 linux/amd64

### Actual Behavior
```
[14:36:18] jnahelou:terraform-provider-foreman git:(master*) $ go install             
# terraform-provider-foreman
./resource_server.go:566: cannot use v.(string) (type string) as type int in assignment
./resource_server.go:569: cannot use v.(string) (type string) as type int in assignment
./resource_server.go:622: cannot use v.(string) (type string) as type []interface {} in assignment

```

Works with following config.

### Terraform Version
Terraform version: 0.9.2 

```
resource "foreman_server" "example" {
  ip                 = "10.12.2.2"
  mac                = "00:50:54:8a:21:79"
  architecture_id    = 1       
  domain_id          = 4          
  operatingsystem_id = 1         
  model_id           = 1                 
  build              = false               
  enabled            = true         
  provision_method   = "build"
  name               = "myserver"
  location_id        = 26
  organization_id    = 32
  environment_id     = 2
  managed            = true
  root_pass          = "password
  comment            = ""
  hostgroup_id       = 3
  owner_id           = 1
  puppet_proxy_id    = 2
  puppet_ca_proxy_id = 2
}
```
